### PR TITLE
Reduce minimum TX fee to relay to 0.001 DOGE

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -54,7 +54,7 @@ static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */
 static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
-static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = COIN;
+static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = COIN / 1000;
 //mlumin 5/2021: adding a minimum Wallet fee vs relay, currently still 1 COIN, to be reduced.
 static const unsigned int DEFAULT_MIN_WALLET_TX_FEE = COIN;
 //! -maxtxfee default


### PR DESCRIPTION
The patch should then work as expected, although I note the fee values in `wallet.h` are lowered, and then overriden by the values in `validation.h` (so it tries generating with a fee of 0.1, and executes with a fee of 1.0).

Tested with three nodes:

1. Qt locally
2. Remote miner
3. Remote node connected to Qt and miner

Sending to node 3 works, and the transaction is relayed to the miner where it is entered into a block (and all pre-1.14.4 nodes will then accept it).
