### PR TITLE
Update wallet tests to adapt to no more dust fees

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -519,11 +519,11 @@ BOOST_AUTO_TEST_CASE(GetMinimumFee_dust_test)
 
     int64_t nMinTxFee = COIN;
 
-    // Confirm dust penalty fees are added on
+    // Confirm dust penalty fees are no longer added on
 
-    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 963, 0, pool), 2 * nMinTxFee);
-    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), 2 * nMinTxFee);
-    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1999, 0, pool), 3 * nMinTxFee);
+    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 963, 0, pool), 1 * nMinTxFee);
+    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), 1 * nMinTxFee);
+    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1999, 0, pool), 2 * nMinTxFee);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Note: Should we remove the dust fee logic entirely now?