### PR TITLE
Remove InitWarning()

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3894,6 +3894,13 @@ bool CWallet::ParameterInteraction()
             return InitError(strprintf(_("Invalid amount for -paytxfee=<amount>: '%s' (must be at least %s)"),
                                        GetArg("-paytxfee", ""), ::minRelayTxFeeRate.ToString()));
         }
+	// if -mintxfee is not set, then a lower payTxFee overrides minTxFee
+	if (!IsArgSet("-mintxfee") && payTxFee < CWallet::minTxFee)
+        {
+            InitWarning(strprintf(_("Automatically lowering -mintxfee to '%s'"), GetArg("-paytxfee","")));
+            LogPrintf("%s: parameter interaction: -paytxfee=%s -> setting -mintxfee=%s\n", __func__, GetArg("-paytxfee",""), GetArg("-paytxfee",""));
+            CWallet:minTxFee = CFeeRate(nFeePerK,1000);
+	}
     }
     if (IsArgSet("-maxtxfee"))
     {


### PR DESCRIPTION
* Remove InitWarning() on paytxfee/mintxfee interaction.
* Replace tabs with space for indentation

Addresses feedback on https://github.com/dogecoin/dogecoin/pull/2437
